### PR TITLE
Add Dockerfile

### DIFF
--- a/gt7.Dockerfile
+++ b/gt7.Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.9
+
+ENV PLAYSTATION_IP=$PLAYSTATION_IP
+ENV DRIVER_NAME=$DRIVER_NAME
+
+WORKDIR /usr/src/app
+
+COPY . .
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+
+ADD https://raw.githubusercontent.com/ddm999/gt7info/web-new/_data/db/cars.csv stm/gt7/db/cars.csv
+ADD https://raw.githubusercontent.com/ddm999/gt7info/web-new/_data/db/course.csv stm/gt7/db/course.csv
+
+RUN chmod -R 755 stm/gt7/db/
+
+CMD [ "python", "gt7-cli.py", "--driver", "$DRIVER_NAME", "$PLAYSTATION_IP"]


### PR DESCRIPTION
I am using your great tool in a Docker container like this:

```yaml
    gt7simtomotec:
        build:
            context: /home/xxx/work/sim-to-motec
            dockerfile: gt7.Dockerfile
        restart: unless-stopped
        container_name: sim-to-motec
        user: "1002"
        ports:
            - "33742:33740/udp"
        volumes:
            - /home/xxx/gt7simtomotec/:/usr/src/app/data
        environment:
            - DRIVER_NAME="Matthias Küch"
            - PLAYSTATION_IP=192.168.178.119 #wifi
            # - PLAYSTATION_IP=192.168.178.21 #wired
            - TZ=Europe/Berlin
```

Please be aware that Docker containers are not allowed to broadcast to 255.255.255.255 by default and have to use IP addresses.